### PR TITLE
🐛 Fix CCS v12 installer download failure caused by incorrect URL directory path.

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -58,7 +58,7 @@ if [ "${MAJOR_VER}" -ge 20 ]; then
     chmod +x "ccs_setup_${VER}.run"
     "./ccs_setup_${VER}.run" --mode unattended --enable-components "${COMPONENTS}" --prefix /opt/ti
 else
-    wget --timeout=300 --tries=3 "${CCS_URL}${VER}/CCS${VER}_linux-x64.tar.gz"
+    wget --timeout=300 --tries=3 "${CCS_URL}${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/CCS${VER}_linux-x64.tar.gz"
     echo ">>> Extracting..."
     tar -zxf "CCS${VER}_linux-x64.tar.gz"
     chmod -R 755 "CCS${VER}_linux-x64"


### PR DESCRIPTION
## Summary

Fix CCS v12 installer download failure caused by incorrect URL directory path.

## Changes

### `entrypoint.sh`

CCS v12 uses a 3-part version format (`MAJOR.MINOR.PATCH`) in its download URL directory, unlike v11 and below which use a 4-part format.

```diff
- wget ... "${CCS_URL}${VER}/CCS${VER}_linux-x64.tar.gz"
+ wget ... "${CCS_URL}${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/CCS${VER}_linux-x64.tar.gz"
```

## Related Issues

Closes #3 