### PR TITLE
🐛 fix CCS v7-v12 install failures and add per-version test workflows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto
+*.sh text eol=lf
+Dockerfile text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 * text=auto
 *.sh text eol=lf
+*.yml text eol=lf
 Dockerfile text eol=lf

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,34 +1,34 @@
 name: Build and Push Docker Image
 
 on:
-  push:
-    branches:
-      - main
-  workflow_dispatch:
+    push:
+        branches:
+            - main
+    workflow_dispatch:
 
 jobs:
-  build-and-push:
-    runs-on: ubuntu-latest
+    build-and-push:
+        runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
 
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+            - name: Log in to Docker Hub
+              uses: docker/login-action@v3
+              with:
+                  username: ${{ secrets.DOCKERHUB_USERNAME }}
+                  password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
 
-      - name: Build and push
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          tags: |
-            uoohyo/ccstudio-ide:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+            - name: Build and push
+              uses: docker/build-push-action@v6
+              with:
+                  context: .
+                  push: true
+                  tags: |
+                      uoohyo/ccstudio-ide:latest
+                  cache-from: type=gha
+                  cache-to: type=gha,mode=max

--- a/.github/workflows/test-v10.yml
+++ b/.github/workflows/test-v10.yml
@@ -1,39 +1,39 @@
 name: Test CCS v10.4.0
 
 on:
-  push:
-    branches:
-      - main
-  workflow_dispatch:
+    push:
+        branches:
+            - main
+    workflow_dispatch: {}
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
+    test:
+        runs-on: ubuntu-latest
+        timeout-minutes: 60
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
 
-      - name: Build image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          load: true
-          tags: ccstudio-ide:test
-          cache-from: type=gha,scope=docker-build
-          cache-to: type=gha,mode=max,scope=docker-build
+            - name: Build image
+              uses: docker/build-push-action@v6
+              with:
+                  context: .
+                  load: true
+                  tags: ccstudio-ide:test
+                  cache-from: type=gha,scope=docker-build
+                  cache-to: type=gha,mode=max,scope=docker-build
 
-      - name: Test CCS v10.4.0
-        run: |
-          docker run --rm \
-            -e MAJOR_VER=10 \
-            -e MINOR_VER=4 \
-            -e PATCH_VER=0 \
-            -e BUILD_VER=00006 \
-            -e COMPONENTS=PF_C28 \
-            ccstudio-ide:test \
-            bash -c "echo 'CCS v10.4.0 verified'"
+            - name: Test CCS v10.4.0
+              run: |
+                  docker run --rm \
+                    -e MAJOR_VER=10 \
+                    -e MINOR_VER=4 \
+                    -e PATCH_VER=0 \
+                    -e BUILD_VER=00006 \
+                    -e COMPONENTS=PF_C28 \
+                    ccstudio-ide:test \
+                    bash -c "echo 'CCS v10.4.0 verified'"

--- a/.github/workflows/test-v10.yml
+++ b/.github/workflows/test-v10.yml
@@ -1,0 +1,39 @@
+name: Test CCS v10.4.0
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: ccstudio-ide:test
+          cache-from: type=gha,scope=docker-build
+          cache-to: type=gha,mode=max,scope=docker-build
+
+      - name: Test CCS v10.4.0
+        run: |
+          docker run --rm \
+            -e MAJOR_VER=10 \
+            -e MINOR_VER=4 \
+            -e PATCH_VER=0 \
+            -e BUILD_VER=00006 \
+            -e COMPONENTS=PF_C28 \
+            ccstudio-ide:test \
+            bash -c "echo 'CCS v10.4.0 verified'"

--- a/.github/workflows/test-v11.yml
+++ b/.github/workflows/test-v11.yml
@@ -1,39 +1,39 @@
 name: Test CCS v11.2.0
 
 on:
-  push:
-    branches:
-      - main
-  workflow_dispatch:
+    push:
+        branches:
+            - main
+    workflow_dispatch: {}
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
+    test:
+        runs-on: ubuntu-latest
+        timeout-minutes: 60
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
 
-      - name: Build image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          load: true
-          tags: ccstudio-ide:test
-          cache-from: type=gha,scope=docker-build
-          cache-to: type=gha,mode=max,scope=docker-build
+            - name: Build image
+              uses: docker/build-push-action@v6
+              with:
+                  context: .
+                  load: true
+                  tags: ccstudio-ide:test
+                  cache-from: type=gha,scope=docker-build
+                  cache-to: type=gha,mode=max,scope=docker-build
 
-      - name: Test CCS v11.2.0
-        run: |
-          docker run --rm \
-            -e MAJOR_VER=11 \
-            -e MINOR_VER=2 \
-            -e PATCH_VER=0 \
-            -e BUILD_VER=00007 \
-            -e COMPONENTS=PF_C28 \
-            ccstudio-ide:test \
-            bash -c "echo 'CCS v11.2.0 verified'"
+            - name: Test CCS v11.2.0
+              run: |
+                  docker run --rm \
+                    -e MAJOR_VER=11 \
+                    -e MINOR_VER=2 \
+                    -e PATCH_VER=0 \
+                    -e BUILD_VER=00007 \
+                    -e COMPONENTS=PF_C28 \
+                    ccstudio-ide:test \
+                    bash -c "echo 'CCS v11.2.0 verified'"

--- a/.github/workflows/test-v11.yml
+++ b/.github/workflows/test-v11.yml
@@ -1,0 +1,39 @@
+name: Test CCS v11.2.0
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: ccstudio-ide:test
+          cache-from: type=gha,scope=docker-build
+          cache-to: type=gha,mode=max,scope=docker-build
+
+      - name: Test CCS v11.2.0
+        run: |
+          docker run --rm \
+            -e MAJOR_VER=11 \
+            -e MINOR_VER=2 \
+            -e PATCH_VER=0 \
+            -e BUILD_VER=00007 \
+            -e COMPONENTS=PF_C28 \
+            ccstudio-ide:test \
+            bash -c "echo 'CCS v11.2.0 verified'"

--- a/.github/workflows/test-v12.yml
+++ b/.github/workflows/test-v12.yml
@@ -1,39 +1,39 @@
 name: Test CCS v12.8.1
 
 on:
-  push:
-    branches:
-      - main
-  workflow_dispatch:
+    push:
+        branches:
+            - main
+    workflow_dispatch: {}
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
+    test:
+        runs-on: ubuntu-latest
+        timeout-minutes: 60
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
 
-      - name: Build image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          load: true
-          tags: ccstudio-ide:test
-          cache-from: type=gha,scope=docker-build
-          cache-to: type=gha,mode=max,scope=docker-build
+            - name: Build image
+              uses: docker/build-push-action@v6
+              with:
+                  context: .
+                  load: true
+                  tags: ccstudio-ide:test
+                  cache-from: type=gha,scope=docker-build
+                  cache-to: type=gha,mode=max,scope=docker-build
 
-      - name: Test CCS v12.8.1
-        run: |
-          docker run --rm \
-            -e MAJOR_VER=12 \
-            -e MINOR_VER=8 \
-            -e PATCH_VER=1 \
-            -e BUILD_VER=00005 \
-            -e COMPONENTS=PF_C28 \
-            ccstudio-ide:test \
-            bash -c "echo 'CCS v12.8.1 verified'"
+            - name: Test CCS v12.8.1
+              run: |
+                  docker run --rm \
+                    -e MAJOR_VER=12 \
+                    -e MINOR_VER=8 \
+                    -e PATCH_VER=1 \
+                    -e BUILD_VER=00005 \
+                    -e COMPONENTS=PF_C28 \
+                    ccstudio-ide:test \
+                    bash -c "echo 'CCS v12.8.1 verified'"

--- a/.github/workflows/test-v12.yml
+++ b/.github/workflows/test-v12.yml
@@ -1,0 +1,39 @@
+name: Test CCS v12.8.1
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: ccstudio-ide:test
+          cache-from: type=gha,scope=docker-build
+          cache-to: type=gha,mode=max,scope=docker-build
+
+      - name: Test CCS v12.8.1
+        run: |
+          docker run --rm \
+            -e MAJOR_VER=12 \
+            -e MINOR_VER=8 \
+            -e PATCH_VER=1 \
+            -e BUILD_VER=00005 \
+            -e COMPONENTS=PF_C28 \
+            ccstudio-ide:test \
+            bash -c "echo 'CCS v12.8.1 verified'"

--- a/.github/workflows/test-v20.yml
+++ b/.github/workflows/test-v20.yml
@@ -1,39 +1,39 @@
 name: Test CCS v20.5.0
 
 on:
-  push:
-    branches:
-      - main
-  workflow_dispatch:
+    push:
+        branches:
+            - main
+    workflow_dispatch: {}
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
+    test:
+        runs-on: ubuntu-latest
+        timeout-minutes: 60
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
 
-      - name: Build image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          load: true
-          tags: ccstudio-ide:test
-          cache-from: type=gha,scope=docker-build
-          cache-to: type=gha,mode=max,scope=docker-build
+            - name: Build image
+              uses: docker/build-push-action@v6
+              with:
+                  context: .
+                  load: true
+                  tags: ccstudio-ide:test
+                  cache-from: type=gha,scope=docker-build
+                  cache-to: type=gha,mode=max,scope=docker-build
 
-      - name: Test CCS v20.5.0
-        run: |
-          docker run --rm \
-            -e MAJOR_VER=20 \
-            -e MINOR_VER=5 \
-            -e PATCH_VER=0 \
-            -e BUILD_VER=00028 \
-            -e COMPONENTS=PF_C28 \
-            ccstudio-ide:test \
-            bash -c "echo 'CCS v20.5.0 verified'"
+            - name: Test CCS v20.5.0
+              run: |
+                  docker run --rm \
+                    -e MAJOR_VER=20 \
+                    -e MINOR_VER=5 \
+                    -e PATCH_VER=0 \
+                    -e BUILD_VER=00028 \
+                    -e COMPONENTS=PF_C28 \
+                    ccstudio-ide:test \
+                    bash -c "echo 'CCS v20.5.0 verified'"

--- a/.github/workflows/test-v20.yml
+++ b/.github/workflows/test-v20.yml
@@ -1,0 +1,39 @@
+name: Test CCS v20.5.0
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: ccstudio-ide:test
+          cache-from: type=gha,scope=docker-build
+          cache-to: type=gha,mode=max,scope=docker-build
+
+      - name: Test CCS v20.5.0
+        run: |
+          docker run --rm \
+            -e MAJOR_VER=20 \
+            -e MINOR_VER=5 \
+            -e PATCH_VER=0 \
+            -e BUILD_VER=00028 \
+            -e COMPONENTS=PF_C28 \
+            ccstudio-ide:test \
+            bash -c "echo 'CCS v20.5.0 verified'"

--- a/.github/workflows/test-v7.yml
+++ b/.github/workflows/test-v7.yml
@@ -1,39 +1,39 @@
 name: Test CCS v7.4.0
 
 on:
-  push:
-    branches:
-      - main
-  workflow_dispatch:
+    push:
+        branches:
+            - main
+    workflow_dispatch: {}
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
+    test:
+        runs-on: ubuntu-latest
+        timeout-minutes: 60
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
 
-      - name: Build image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          load: true
-          tags: ccstudio-ide:test
-          cache-from: type=gha,scope=docker-build
-          cache-to: type=gha,mode=max,scope=docker-build
+            - name: Build image
+              uses: docker/build-push-action@v6
+              with:
+                  context: .
+                  load: true
+                  tags: ccstudio-ide:test
+                  cache-from: type=gha,scope=docker-build
+                  cache-to: type=gha,mode=max,scope=docker-build
 
-      - name: Test CCS v7.4.0
-        run: |
-          docker run --rm \
-            -e MAJOR_VER=7 \
-            -e MINOR_VER=4 \
-            -e PATCH_VER=0 \
-            -e BUILD_VER=00015 \
-            -e COMPONENTS=PF_C28 \
-            ccstudio-ide:test \
-            bash -c "echo 'CCS v7.4.0 verified'"
+            - name: Test CCS v7.4.0
+              run: |
+                  docker run --rm \
+                    -e MAJOR_VER=7 \
+                    -e MINOR_VER=4 \
+                    -e PATCH_VER=0 \
+                    -e BUILD_VER=00015 \
+                    -e COMPONENTS=PF_C28 \
+                    ccstudio-ide:test \
+                    bash -c "echo 'CCS v7.4.0 verified'"

--- a/.github/workflows/test-v7.yml
+++ b/.github/workflows/test-v7.yml
@@ -1,0 +1,39 @@
+name: Test CCS v7.4.0
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: ccstudio-ide:test
+          cache-from: type=gha,scope=docker-build
+          cache-to: type=gha,mode=max,scope=docker-build
+
+      - name: Test CCS v7.4.0
+        run: |
+          docker run --rm \
+            -e MAJOR_VER=7 \
+            -e MINOR_VER=4 \
+            -e PATCH_VER=0 \
+            -e BUILD_VER=00015 \
+            -e COMPONENTS=PF_C28 \
+            ccstudio-ide:test \
+            bash -c "echo 'CCS v7.4.0 verified'"

--- a/.github/workflows/test-v8.yml
+++ b/.github/workflows/test-v8.yml
@@ -1,0 +1,39 @@
+name: Test CCS v8.3.1
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: ccstudio-ide:test
+          cache-from: type=gha,scope=docker-build
+          cache-to: type=gha,mode=max,scope=docker-build
+
+      - name: Test CCS v8.3.1
+        run: |
+          docker run --rm \
+            -e MAJOR_VER=8 \
+            -e MINOR_VER=3 \
+            -e PATCH_VER=1 \
+            -e BUILD_VER=00004 \
+            -e COMPONENTS=PF_C28 \
+            ccstudio-ide:test \
+            bash -c "echo 'CCS v8.3.1 verified'"

--- a/.github/workflows/test-v8.yml
+++ b/.github/workflows/test-v8.yml
@@ -1,39 +1,39 @@
 name: Test CCS v8.3.1
 
 on:
-  push:
-    branches:
-      - main
-  workflow_dispatch:
+    push:
+        branches:
+            - main
+    workflow_dispatch: {}
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
+    test:
+        runs-on: ubuntu-latest
+        timeout-minutes: 60
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
 
-      - name: Build image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          load: true
-          tags: ccstudio-ide:test
-          cache-from: type=gha,scope=docker-build
-          cache-to: type=gha,mode=max,scope=docker-build
+            - name: Build image
+              uses: docker/build-push-action@v6
+              with:
+                  context: .
+                  load: true
+                  tags: ccstudio-ide:test
+                  cache-from: type=gha,scope=docker-build
+                  cache-to: type=gha,mode=max,scope=docker-build
 
-      - name: Test CCS v8.3.1
-        run: |
-          docker run --rm \
-            -e MAJOR_VER=8 \
-            -e MINOR_VER=3 \
-            -e PATCH_VER=1 \
-            -e BUILD_VER=00004 \
-            -e COMPONENTS=PF_C28 \
-            ccstudio-ide:test \
-            bash -c "echo 'CCS v8.3.1 verified'"
+            - name: Test CCS v8.3.1
+              run: |
+                  docker run --rm \
+                    -e MAJOR_VER=8 \
+                    -e MINOR_VER=3 \
+                    -e PATCH_VER=1 \
+                    -e BUILD_VER=00004 \
+                    -e COMPONENTS=PF_C28 \
+                    ccstudio-ide:test \
+                    bash -c "echo 'CCS v8.3.1 verified'"

--- a/.github/workflows/test-v9.yml
+++ b/.github/workflows/test-v9.yml
@@ -1,39 +1,39 @@
 name: Test CCS v9.3.0
 
 on:
-  push:
-    branches:
-      - main
-  workflow_dispatch:
+    push:
+        branches:
+            - main
+    workflow_dispatch: {}
 
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
+    test:
+        runs-on: ubuntu-latest
+        timeout-minutes: 60
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v3
 
-      - name: Build image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          load: true
-          tags: ccstudio-ide:test
-          cache-from: type=gha,scope=docker-build
-          cache-to: type=gha,mode=max,scope=docker-build
+            - name: Build image
+              uses: docker/build-push-action@v6
+              with:
+                  context: .
+                  load: true
+                  tags: ccstudio-ide:test
+                  cache-from: type=gha,scope=docker-build
+                  cache-to: type=gha,mode=max,scope=docker-build
 
-      - name: Test CCS v9.3.0
-        run: |
-          docker run --rm \
-            -e MAJOR_VER=9 \
-            -e MINOR_VER=3 \
-            -e PATCH_VER=0 \
-            -e BUILD_VER=00012 \
-            -e COMPONENTS=PF_C28 \
-            ccstudio-ide:test \
-            bash -c "echo 'CCS v9.3.0 verified'"
+            - name: Test CCS v9.3.0
+              run: |
+                  docker run --rm \
+                    -e MAJOR_VER=9 \
+                    -e MINOR_VER=3 \
+                    -e PATCH_VER=0 \
+                    -e BUILD_VER=00012 \
+                    -e COMPONENTS=PF_C28 \
+                    ccstudio-ide:test \
+                    bash -c "echo 'CCS v9.3.0 verified'"

--- a/.github/workflows/test-v9.yml
+++ b/.github/workflows/test-v9.yml
@@ -1,0 +1,39 @@
+name: Test CCS v9.3.0
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: ccstudio-ide:test
+          cache-from: type=gha,scope=docker-build
+          cache-to: type=gha,mode=max,scope=docker-build
+
+      - name: Test CCS v9.3.0
+        run: |
+          docker run --rm \
+            -e MAJOR_VER=9 \
+            -e MINOR_VER=3 \
+            -e PATCH_VER=0 \
+            -e BUILD_VER=00012 \
+            -e COMPONENTS=PF_C28 \
+            ccstudio-ide:test \
+            bash -c "echo 'CCS v9.3.0 verified'"

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,14 @@ RUN echo ">>> Installing system dependencies..." && \
     libxtst6 \
     libxrender1 \
     libusb-1.0-0-dev \
+    libgconf-2-4 \
+    libncurses5 \
+    libtinfo5 \
+    libusb-0.1-4 \
+    libdbus-glib-1-2 \
+    libgtk2.0-0 \
+    libxt6 \
+    libcanberra0 \
     ca-certificates \
     build-essential \
     unzip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,7 @@ WORKDIR /home
 ENV PATH="/opt/ti/ccs/eclipse/:${PATH}"
 
 # Entrypoint
-COPY --chmod=755 entrypoint.sh /entrypoint.sh
+COPY entrypoint.sh /entrypoint.sh
+RUN sed -i 's/\r//' /entrypoint.sh && chmod 755 /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,14 @@ RUN echo ">>> Installing system dependencies..." && \
     libtinfo5:i386 \
     libpython2.7 \
     libudev1 \
+    libasound2 \
+    libatk1.0-0 \
+    libcairo2 \
+    libgtk-3-0 \
+    libxi6 \
+    libxtst6 \
+    libxrender1 \
+    libusb-1.0-0-dev \
     ca-certificates \
     build-essential \
     unzip \

--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@
 <img src="./.github/docker-ccstudio-ide.jpg" width=256 height=256 alt="docker-ccstudio-ide" />
 <!-- markdownlint-enable MD033 -->
 
+[![Build](https://github.com/uoohyo/docker-ccstudio-ide/actions/workflows/docker-publish.yml/badge.svg)](https://github.com/uoohyo/docker-ccstudio-ide/actions/workflows/docker-publish.yml)
+
+| CCS Version   | Status                                                                                                                                                                                      |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| v20.5.0.00028 | [![Test CCS v20.5.0](https://github.com/uoohyo/docker-ccstudio-ide/actions/workflows/test-v20.yml/badge.svg)](https://github.com/uoohyo/docker-ccstudio-ide/actions/workflows/test-v20.yml) |
+| v12.8.1.00005 | [![Test CCS v12.8.1](https://github.com/uoohyo/docker-ccstudio-ide/actions/workflows/test-v12.yml/badge.svg)](https://github.com/uoohyo/docker-ccstudio-ide/actions/workflows/test-v12.yml) |
+| v11.2.0.00007 | [![Test CCS v11.2.0](https://github.com/uoohyo/docker-ccstudio-ide/actions/workflows/test-v11.yml/badge.svg)](https://github.com/uoohyo/docker-ccstudio-ide/actions/workflows/test-v11.yml) |
+| v10.4.0.00006 | [![Test CCS v10.4.0](https://github.com/uoohyo/docker-ccstudio-ide/actions/workflows/test-v10.yml/badge.svg)](https://github.com/uoohyo/docker-ccstudio-ide/actions/workflows/test-v10.yml) |
+| v9.3.0.00012  | [![Test CCS v9.3.0](https://github.com/uoohyo/docker-ccstudio-ide/actions/workflows/test-v9.yml/badge.svg)](https://github.com/uoohyo/docker-ccstudio-ide/actions/workflows/test-v9.yml)    |
+| v8.3.1.00004  | [![Test CCS v8.3.1](https://github.com/uoohyo/docker-ccstudio-ide/actions/workflows/test-v8.yml/badge.svg)](https://github.com/uoohyo/docker-ccstudio-ide/actions/workflows/test-v8.yml)    |
+| v7.4.0.00015  | [![Test CCS v7.4.0](https://github.com/uoohyo/docker-ccstudio-ide/actions/workflows/test-v7.yml/badge.svg)](https://github.com/uoohyo/docker-ccstudio-ide/actions/workflows/test-v7.yml)    |
+
 The [`docker-ccstudio-ide`](https://github.com/uoohyo/docker-ccstudio-ide) Docker image provides a CI/CD environment for projects developed in the Code Composer Studio IDE from Texas Instruments. Code Composer Studio is an integrated development environment (IDE) for TI's microcontrollers and processors, comprising a suite of tools used to develop and debug embedded applications.
 
 > **Note:** CCS is downloaded and installed when the container starts, not at image build time. An internet connection is required at runtime.
@@ -55,35 +67,35 @@ For the latest version information, visit [this link](https://www.ti.com/tool/do
 
 #### Components
 
-Component selection via the `COMPONENTS` variable is supported on **CCS v9.2.0 and above**. For CCS v9.1 and below, the `COMPONENTS` variable is ignored and all product families are installed.
+Component selection via the `COMPONENTS` variable is supported on **CCS v10 and above**. For CCS v9 and below, the `COMPONENTS` variable is ignored and all product families are installed.
 
 When installing [Code Composer Studio](https://www.ti.com/tool/CCSTUDIO), you can choose from various [Texas Instruments Inc.](https://www.ti.com/) product families. Below is a list of installable product families:
 
-|Product family     |Description                                                                    |
-|-------------------|-------------------------------------------------------------------------------|
-|PF_MSP430          |MSP430 ultra-low power MCUs                                                    |
-|PF_MSP432          |SimpleLink™ MSP432™ low power + performance MCUs                               |
-|PF_CC2X            |SimpleLink™ CC13xx and CC26xx Wireless MCUs                                    |
-|PF_CC3X            |SimpleLink™ Wi-Fi® CC32xx Wireless MCUs                                        |
-|PF_CC2538          |CC2538 IEEE 802.15.4 Wireless MCUs                                             |
-|PF_C28             |C2000 real-time MCUs                                                           |
-|PF_TM4C            |TM4C12x ARM® Cortex®-M4F core-based MCUs                                       |
-|PF_PGA             |PGA Sensor Signal Conditioners                                                 |
-|PF_HERCULES        |Hercules™ Safety MCUs                                                          |
-|PF_SITARA          |Sitara™ AM3x, AM4x, AM5x and AM6x MPUs (will also include AM2x for CCS 10.x)   |
-|PF_SITARA_MCU      |Sitara™ AM2x MCUs (only supported in CCS 11.x and greater)                     |
-|PF_OMAPL           |OMAP-L1x DSP + ARM9® Processor                                                 |
-|PF_DAVINCI         |DaVinci (DM) Video Processors                                                  |
-|PF_OMAP            |OMAP Processors                                                                |
-|PF_TDA_DRA         |TDAx Driver Assistance SoCs & Jacinto DRAx Infotainment SoCs                   |
-|PF_C55             |C55x ultra-low-power DSP                                                       |
-|PF_C6000SC         |C6000 Power-Optimized DSP                                                      |
-|PF_C66AK_KEYSTONE  |66AK2x multicore DSP + ARM® Processors & C66x KeyStone™ multicore DSP          |
-|PF_MMWAVE          |mmWave Sensors                                                                 |
-|PF_C64MC           |C64x multicore DSP                                                             |
-|PF_DIGITAL_POWER   |UCD Digital Power Controllers                                                  |
+| Product family    | Description                                                                  |
+| ----------------- | ---------------------------------------------------------------------------- |
+| PF_MSP430         | MSP430 ultra-low power MCUs                                                  |
+| PF_MSP432         | SimpleLink™ MSP432™ low power + performance MCUs                             |
+| PF_CC2X           | SimpleLink™ CC13xx and CC26xx Wireless MCUs                                  |
+| PF_CC3X           | SimpleLink™ Wi-Fi® CC32xx Wireless MCUs                                      |
+| PF_CC2538         | CC2538 IEEE 802.15.4 Wireless MCUs                                           |
+| PF_C28            | C2000 real-time MCUs                                                         |
+| PF_TM4C           | TM4C12x ARM® Cortex®-M4F core-based MCUs                                     |
+| PF_PGA            | PGA Sensor Signal Conditioners                                               |
+| PF_HERCULES       | Hercules™ Safety MCUs                                                        |
+| PF_SITARA         | Sitara™ AM3x, AM4x, AM5x and AM6x MPUs (will also include AM2x for CCS 10.x) |
+| PF_SITARA_MCU     | Sitara™ AM2x MCUs (only supported in CCS 11.x and greater)                   |
+| PF_OMAPL          | OMAP-L1x DSP + ARM9® Processor                                               |
+| PF_DAVINCI        | DaVinci (DM) Video Processors                                                |
+| PF_OMAP           | OMAP Processors                                                              |
+| PF_TDA_DRA        | TDAx Driver Assistance SoCs & Jacinto DRAx Infotainment SoCs                 |
+| PF_C55            | C55x ultra-low-power DSP                                                     |
+| PF_C6000SC        | C6000 Power-Optimized DSP                                                    |
+| PF_C66AK_KEYSTONE | 66AK2x multicore DSP + ARM® Processors & C66x KeyStone™ multicore DSP        |
+| PF_MMWAVE         | mmWave Sensors                                                               |
+| PF_C64MC          | C64x multicore DSP                                                           |
+| PF_DIGITAL_POWER  | UCD Digital Power Controllers                                                |
 
-> **Note:** For CCS v9.1 and below, the installer does not support component selection. All product families will be installed regardless of the `COMPONENTS` value, which will result in a larger installation size.
+> **Note:** For CCS v9 and below, the installer does not support component selection. All product families will be installed regardless of the `COMPONENTS` value, which will result in a larger installation size.
 
 Multiple product families can be installed by separating their names with a comma in the `COMPONENTS` variable. Here is an example that installs development tools for both PF_MSP430 and PF_CC2X:
 
@@ -109,11 +121,11 @@ Build a project using specific configuration:
 
 Import a project into the workspace:
 
-    eclipsec -noSplash -data <workspace_path> -application com.ti.ccstudio.apps.projectImport -ccs.location <project_path>
+    eclipse -noSplash -data <workspace_path> -application com.ti.ccstudio.apps.projectImport -ccs.location <project_path>
 
 Build a project using specific configuration:
 
-    eclipsec -noSplash -data <workspace_path> -application com.ti.ccstudio.apps.projectBuild -ccs.projects <project_name> -ccs.configuration <build_name>
+    eclipse -noSplash -data <workspace_path> -application com.ti.ccstudio.apps.projectBuild -ccs.projects <project_name> -ccs.configuration <build_name>
 
 These commands manage projects within the Code Composer Studio environment without the need for a graphical interface, making them ideal for automated environments such as continuous integration setups.
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ For the latest version information, visit [this link](https://www.ti.com/tool/do
 
 #### Components
 
+Component selection via the `COMPONENTS` variable is supported on **CCS v9.2.0 and above**. For CCS v9.1 and below, the `COMPONENTS` variable is ignored and all product families are installed.
+
 When installing [Code Composer Studio](https://www.ti.com/tool/CCSTUDIO), you can choose from various [Texas Instruments Inc.](https://www.ti.com/) product families. Below is a list of installable product families:
 
 |Product family     |Description                                                                    |
@@ -80,6 +82,8 @@ When installing [Code Composer Studio](https://www.ti.com/tool/CCSTUDIO), you ca
 |PF_MMWAVE          |mmWave Sensors                                                                 |
 |PF_C64MC           |C64x multicore DSP                                                             |
 |PF_DIGITAL_POWER   |UCD Digital Power Controllers                                                  |
+
+> **Note:** For CCS v9.1 and below, the installer does not support component selection. All product families will be installed regardless of the `COMPONENTS` value, which will result in a larger installation size.
 
 Multiple product families can be installed by separating their names with a comma in the `COMPONENTS` variable. Here is an example that installs development tools for both PF_MSP430 and PF_CC2X:
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,8 +22,8 @@ EOF
 # Variables
 CCS_URL="https://dr-download.ti.com/software-development/ide-configuration-compiler-or-debugger/MD-J1VdearkvK/"
 VER="${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}.${BUILD_VER}"
-# v20+: installs to /opt/ti/ccs/eclipse; v12-: installs to /opt/ti/ccsv<MAJOR>/eclipse
-if [ "${MAJOR_VER}" -ge 20 ]; then
+# v9+: installs to /opt/ti/ccs/eclipse; v8-: installs to /opt/ti/ccsv<MAJOR>/eclipse
+if [ "${MAJOR_VER}" -ge 9 ]; then
     CCS_ECLIPSE_DIR="/opt/ti/ccs/eclipse"
 else
     CCS_ECLIPSE_DIR="/opt/ti/ccsv${MAJOR_VER}/eclipse"
@@ -33,8 +33,8 @@ export PATH="${CCS_ECLIPSE_DIR}:${PATH}"
 # Download and Install CCS
 # v20+:  zip package, CCS_ prefix, URL path: MAJOR.MINOR.PATCH
 # v12-:  tar.gz package, CCS prefix, URL path: MAJOR.MINOR.PATCH (v12) or MAJOR.MINOR.PATCH.BUILD (v11-)
-# v9.2+: installer binary is ccs_setup_<VER>.run, supports --enable-components (PF_* IDs)
-# v9.1-: installer binary is ccs_setup_linux64_<VER>.bin, --enable-components not supported
+# v10+:  installer binary is ccs_setup_<VER>.run, supports --enable-components (PF_* IDs)
+# v9-:   installer binary is ccs_setup_linux64_<VER>.bin, --enable-components not supported
 # v20+: udev stubs required — BlackHawk installer calls udev/kernel commands unavailable in Docker
 #       Ref: https://e2e.ti.com/support/tools/code-composer-studio-group/ccs/f/code-composer-studio-forum/1532443
 echo "=== CCS Installation ==="
@@ -91,14 +91,14 @@ else
     tar -zxf "CCS${VER}_linux-x64.tar.gz"
     chmod -R 755 "CCS${VER}_linux-x64"
     echo ">>> Installing CCS ${VER} (this may take a while)..."
-    # v9.2+: new installer (.run, supports --enable-components with PF_* IDs)
-    # v9.1-: old BitRock installer (linux64_*.bin, --enable-components not supported)
-    if [ "${MAJOR_VER}" -ge 10 ] || ([ "${MAJOR_VER}" -eq 9 ] && [ "${MINOR_VER}" -ge 2 ]); then
+    # v10+: new installer (.run, supports --enable-components with PF_* IDs)
+    # v9-:  old BitRock installer (linux64_*.bin, --enable-components not supported)
+    if [ "${MAJOR_VER}" -ge 10 ]; then
         "./CCS${VER}_linux-x64/ccs_setup_${VER}.run" \
             --mode unattended --enable-components "${COMPONENTS}" --prefix /opt/ti \
             --install-BlackHawk false --install-Segger false 2>&1 | tee "${INSTALL_LOG}"
     else
-        echo ">>> Note: --enable-components is not supported for CCS v9.1 and below. Installing all components."
+        echo ">>> Note: --enable-components is not supported for CCS v9 and below. Installing all components."
         "./CCS${VER}_linux-x64/ccs_setup_linux64_${VER}.bin" \
             --mode unattended --prefix /opt/ti \
             --install-BlackHawk false --install-Segger false 2>&1 | tee "${INSTALL_LOG}"
@@ -106,6 +106,9 @@ else
 fi
 
 # Verify Installation
+# v20+: Theia-based, check ccs-server-cli.sh
+# v9+:  Eclipse-based with eclipsec
+# v8-:  Eclipse-based, only eclipse binary (no eclipsec)
 echo ">>> Verifying CCS installation..."
 if [ "${MAJOR_VER}" -ge 20 ]; then
     if ! test -x "${CCS_ECLIPSE_DIR}/ccs-server-cli.sh"; then
@@ -113,9 +116,15 @@ if [ "${MAJOR_VER}" -ge 20 ]; then
         _show_install_logs
         exit 1
     fi
-else
+elif [ "${MAJOR_VER}" -ge 9 ]; then
     if ! test -x "${CCS_ECLIPSE_DIR}/eclipsec"; then
         echo "[ERROR] CCS installation failed: eclipsec not found"
+        _show_install_logs
+        exit 1
+    fi
+else
+    if ! test -x "${CCS_ECLIPSE_DIR}/eclipse"; then
+        echo "[ERROR] CCS installation failed: eclipse not found"
         _show_install_logs
         exit 1
     fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,10 +31,10 @@ fi
 export PATH="${CCS_ECLIPSE_DIR}:${PATH}"
 
 # Download and Install CCS
-# v20+: zip package, CCS_ prefix, URL path: MAJOR.MINOR.PATCH
-# v12-: tar.gz package, CCS prefix, URL path: MAJOR.MINOR.PATCH (v12) or MAJOR.MINOR.PATCH.BUILD (v11-)
-# v10+: installer binary is ccs_setup_<VER>.run
-# v9-:  installer binary is ccs_setup_linux64_<VER>.bin
+# v20+:  zip package, CCS_ prefix, URL path: MAJOR.MINOR.PATCH
+# v12-:  tar.gz package, CCS prefix, URL path: MAJOR.MINOR.PATCH (v12) or MAJOR.MINOR.PATCH.BUILD (v11-)
+# v9.2+: installer binary is ccs_setup_<VER>.run, supports --enable-components (PF_* IDs)
+# v9.1-: installer binary is ccs_setup_linux64_<VER>.bin, --enable-components not supported
 # v20+: udev stubs required — BlackHawk installer calls udev/kernel commands unavailable in Docker
 #       Ref: https://e2e.ti.com/support/tools/code-composer-studio-group/ccs/f/code-composer-studio-forum/1532443
 echo "=== CCS Installation ==="
@@ -91,14 +91,16 @@ else
     tar -zxf "CCS${VER}_linux-x64.tar.gz"
     chmod -R 755 "CCS${VER}_linux-x64"
     echo ">>> Installing CCS ${VER} (this may take a while)..."
-    # v10+: ccs_setup_<VER>.run; v9 and below: ccs_setup_linux64_<VER>.bin
-    if [ "${MAJOR_VER}" -ge 10 ]; then
+    # v9.2+: new installer (.run, supports --enable-components with PF_* IDs)
+    # v9.1-: old BitRock installer (linux64_*.bin, --enable-components not supported)
+    if [ "${MAJOR_VER}" -ge 10 ] || ([ "${MAJOR_VER}" -eq 9 ] && [ "${MINOR_VER}" -ge 2 ]); then
         "./CCS${VER}_linux-x64/ccs_setup_${VER}.run" \
             --mode unattended --enable-components "${COMPONENTS}" --prefix /opt/ti \
             --install-BlackHawk false --install-Segger false 2>&1 | tee "${INSTALL_LOG}"
     else
+        echo ">>> Note: --enable-components is not supported for CCS v9.1 and below. Installing all components."
         "./CCS${VER}_linux-x64/ccs_setup_linux64_${VER}.bin" \
-            --mode unattended --enable-components "${COMPONENTS}" --prefix /opt/ti \
+            --mode unattended --prefix /opt/ti \
             --install-BlackHawk false --install-Segger false 2>&1 | tee "${INSTALL_LOG}"
     fi
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -78,7 +78,13 @@ if [ "${MAJOR_VER}" -ge 20 ]; then
     chmod +x "ccs_setup_${VER}.run"
     "./ccs_setup_${VER}.run" --mode unattended --enable-components "${COMPONENTS}" --prefix /opt/ti 2>&1 | tee "${INSTALL_LOG}"
 else
-    wget --timeout=300 --tries=3 "${CCS_URL}${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/CCS${VER}_linux-x64.tar.gz"
+    # v12: URL path is 3-part (MAJOR.MINOR.PATCH); v11 and below: 4-part (MAJOR.MINOR.PATCH.BUILD)
+    if [ "${MAJOR_VER}" -ge 12 ]; then
+        CCS_DL_PATH="${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}"
+    else
+        CCS_DL_PATH="${VER}"
+    fi
+    wget --timeout=300 --tries=3 "${CCS_URL}${CCS_DL_PATH}/CCS${VER}_linux-x64.tar.gz"
     echo ">>> Extracting..."
     tar -zxf "CCS${VER}_linux-x64.tar.gz"
     chmod -R 755 "CCS${VER}_linux-x64"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -86,20 +86,32 @@ else
     else
         CCS_DL_PATH="${VER}"
     fi
+    # Driver install scripts (bh_driver_install.sh for v7-v9, ti_permissions_install.sh for v10-v12)
+    # copy udev rules then try to restart the udev service, which doesn't exist in Docker:
+    #   v7-v9:   'service udev restart'  → "udev: unrecognized service"
+    #   v10-v12: 'systemctl restart udev' → "not booted with systemd"
+    # Either failure causes the BitRock/Run installer to roll back the full installation.
+    # Fix: create required dirs, stub udev init script, and redirect udev-related commands to /bin/true.
+    # /root/.ti is read by the installer's fs --clean step; missing it causes a boost::filesystem crash.
+    mkdir -p /etc/init.d /etc/udev/rules.d /root/.ti
+    printf '#!/bin/sh\nexit 0\n' > /etc/init.d/udev && chmod 755 /etc/init.d/udev
+    ln -sf /bin/true /usr/local/bin/udevadm
+    ln -sf /bin/true /usr/local/bin/systemctl
     wget --timeout=300 --tries=3 "${CCS_URL}${CCS_DL_PATH}/CCS${VER}_linux-x64.tar.gz"
     echo ">>> Extracting..."
     tar -zxf "CCS${VER}_linux-x64.tar.gz"
     chmod -R 755 "CCS${VER}_linux-x64"
     echo ">>> Installing CCS ${VER} (this may take a while)..."
     # v10+: new installer (.run, supports --enable-components with PF_* IDs)
-    # v9-:  old BitRock installer (linux64_*.bin, --enable-components not supported)
+    # v9-:  old BitRock installer; binary name varies (linux64_*.bin or *.run), use find to detect
     if [ "${MAJOR_VER}" -ge 10 ]; then
         "./CCS${VER}_linux-x64/ccs_setup_${VER}.run" \
             --mode unattended --enable-components "${COMPONENTS}" --prefix /opt/ti \
             --install-BlackHawk false --install-Segger false 2>&1 | tee "${INSTALL_LOG}"
     else
         echo ">>> Note: --enable-components is not supported for CCS v9 and below. Installing all components."
-        "./CCS${VER}_linux-x64/ccs_setup_linux64_${VER}.bin" \
+        INSTALLER_BIN=$(find "./CCS${VER}_linux-x64" -maxdepth 1 \( -name "*.bin" -o -name "*.run" \) | sort | head -1)
+        "${INSTALLER_BIN}" \
             --mode unattended --prefix /opt/ti \
             --install-BlackHawk false --install-Segger false 2>&1 | tee "${INSTALL_LOG}"
     fi
@@ -107,18 +119,11 @@ fi
 
 # Verify Installation
 # v20+: Theia-based, check ccs-server-cli.sh
-# v9+:  Eclipse-based with eclipsec
-# v8-:  Eclipse-based, only eclipse binary (no eclipsec)
+# v19-: Eclipse-based, binary is always named 'eclipse' (not 'eclipsec')
 echo ">>> Verifying CCS installation..."
 if [ "${MAJOR_VER}" -ge 20 ]; then
     if ! test -x "${CCS_ECLIPSE_DIR}/ccs-server-cli.sh"; then
         echo "[ERROR] CCS installation failed: ccs-server-cli.sh not found"
-        _show_install_logs
-        exit 1
-    fi
-elif [ "${MAJOR_VER}" -ge 9 ]; then
-    if ! test -x "${CCS_ECLIPSE_DIR}/eclipsec"; then
-        echo "[ERROR] CCS installation failed: eclipsec not found"
         _show_install_logs
         exit 1
     fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,7 +32,9 @@ export PATH="${CCS_ECLIPSE_DIR}:${PATH}"
 
 # Download and Install CCS
 # v20+: zip package, CCS_ prefix, URL path: MAJOR.MINOR.PATCH
-# v12-: tar.gz package, CCS prefix, URL path: MAJOR.MINOR.PATCH.BUILD
+# v12-: tar.gz package, CCS prefix, URL path: MAJOR.MINOR.PATCH (v12) or MAJOR.MINOR.PATCH.BUILD (v11-)
+# v10+: installer binary is ccs_setup_<VER>.run
+# v9-:  installer binary is ccs_setup_linux64_<VER>.bin
 # v20+: udev stubs required — BlackHawk installer calls udev/kernel commands unavailable in Docker
 #       Ref: https://e2e.ti.com/support/tools/code-composer-studio-group/ccs/f/code-composer-studio-forum/1532443
 echo "=== CCS Installation ==="
@@ -89,9 +91,16 @@ else
     tar -zxf "CCS${VER}_linux-x64.tar.gz"
     chmod -R 755 "CCS${VER}_linux-x64"
     echo ">>> Installing CCS ${VER} (this may take a while)..."
-    "./CCS${VER}_linux-x64/ccs_setup_${VER}.run" \
-        --mode unattended --enable-components "${COMPONENTS}" --prefix /opt/ti \
-        --install-BlackHawk false --install-Segger false 2>&1 | tee "${INSTALL_LOG}"
+    # v10+: ccs_setup_<VER>.run; v9 and below: ccs_setup_linux64_<VER>.bin
+    if [ "${MAJOR_VER}" -ge 10 ]; then
+        "./CCS${VER}_linux-x64/ccs_setup_${VER}.run" \
+            --mode unattended --enable-components "${COMPONENTS}" --prefix /opt/ti \
+            --install-BlackHawk false --install-Segger false 2>&1 | tee "${INSTALL_LOG}"
+    else
+        "./CCS${VER}_linux-x64/ccs_setup_linux64_${VER}.bin" \
+            --mode unattended --enable-components "${COMPONENTS}" --prefix /opt/ti \
+            --install-BlackHawk false --install-Segger false 2>&1 | tee "${INSTALL_LOG}"
+    fi
 fi
 
 # Verify Installation

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -41,8 +41,22 @@ echo "Components : ${COMPONENTS}"
 echo ""
 
 # Create temporary directory for installation
+INSTALL_LOG="/tmp/ccs_install.log"
 mkdir -p /ccs_install
 cd /ccs_install
+
+_show_install_logs() {
+    echo ""
+    echo "=== Installer Output ==="
+    cat "${INSTALL_LOG}" 2>/dev/null || echo "(no output captured)"
+    echo ""
+    echo "=== TI Installer Logs ==="
+    find /root/.ti /tmp /opt/ti -name "*.log" 2>/dev/null | while read -r f; do
+        echo "--- ${f} ---"
+        cat "${f}"
+    done
+    echo "========================"
+}
 
 # Download and Install CCS
 echo ">>> Downloading CCS ${VER}..."
@@ -62,7 +76,7 @@ if [ "${MAJOR_VER}" -ge 20 ]; then
     echo ">>> Installing CCS ${VER} (this may take a while)..."
     cd "CCS_${VER}_linux"
     chmod +x "ccs_setup_${VER}.run"
-    "./ccs_setup_${VER}.run" --mode unattended --enable-components "${COMPONENTS}" --prefix /opt/ti
+    "./ccs_setup_${VER}.run" --mode unattended --enable-components "${COMPONENTS}" --prefix /opt/ti 2>&1 | tee "${INSTALL_LOG}"
 else
     wget --timeout=300 --tries=3 "${CCS_URL}${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/CCS${VER}_linux-x64.tar.gz"
     echo ">>> Extracting..."
@@ -71,15 +85,23 @@ else
     echo ">>> Installing CCS ${VER} (this may take a while)..."
     "./CCS${VER}_linux-x64/ccs_setup_${VER}.run" \
         --mode unattended --enable-components "${COMPONENTS}" --prefix /opt/ti \
-        --install-BlackHawk false --install-Segger false
+        --install-BlackHawk false --install-Segger false 2>&1 | tee "${INSTALL_LOG}"
 fi
 
 # Verify Installation
 echo ">>> Verifying CCS installation..."
 if [ "${MAJOR_VER}" -ge 20 ]; then
-    test -x "${CCS_ECLIPSE_DIR}/ccs-server-cli.sh" || { echo "[ERROR] CCS installation failed: ccs-server-cli.sh not found"; exit 1; }
+    if ! test -x "${CCS_ECLIPSE_DIR}/ccs-server-cli.sh"; then
+        echo "[ERROR] CCS installation failed: ccs-server-cli.sh not found"
+        _show_install_logs
+        exit 1
+    fi
 else
-    test -x "${CCS_ECLIPSE_DIR}/eclipsec" || { echo "[ERROR] CCS installation failed: eclipsec not found"; exit 1; }
+    if ! test -x "${CCS_ECLIPSE_DIR}/eclipsec"; then
+        echo "[ERROR] CCS installation failed: eclipsec not found"
+        _show_install_logs
+        exit 1
+    fi
 fi
 echo ">>> CCS ${VER} installation complete."
 


### PR DESCRIPTION
## Summary

- Fix CCS v7–v12 Docker installation failures caused by missing udev stubs and incorrect binary verification
- Add GitHub Actions test workflows for each CCS version (v7–v20)
- Update README with build badge and CCS version test status table

## Changes

### Bug Fixes (`entrypoint.sh`)
- Stub `udevadm`, `systemctl`, `/etc/init.d/udev` to prevent installer rollback in Docker (v7–v12)
- Create `/etc/udev/rules.d` and `/root/.ti` directories required by post-install scripts
- Auto-detect v9 installer binary name with `find` instead of hardcoded filename
- Fix verification to check `eclipse` binary instead of `eclipsec` (v9–v19 never install `eclipsec`)

### CI (`docker-publish.yml`, `test-v*.yml`)
- Add per-version test workflows (v7.4.0 / v8.3.1 / v9.3.0 / v10.4.0 / v11.2.0 / v12.8.1 / v20.5.0)
- Triggered on push to `main` and `workflow_dispatch`
- Shared GHA build cache across all test workflows

### Documentation (`README.md`)
- Add build badge and per-version test status table
- Fix `eclipsec` → `eclipse` in usage commands
- Fix component selection boundary from v9.2 to v10