### PR TITLE
🐛 fix CI/CD pipeline: runner failures, scraper, permissions, and Node.js upgrade

### DIFF
--- a/.github/scripts/merge-versions.js
+++ b/.github/scripts/merge-versions.js
@@ -25,5 +25,5 @@ process.stdin.on('end', () => {
 
   if (versions.length > 0) versions[0].is_latest = true;
 
-  console.log(JSON.stringify(versions, null, 2));
+  console.log(JSON.stringify(versions));
 });

--- a/.github/scripts/scrape-versions.js
+++ b/.github/scripts/scrape-versions.js
@@ -91,15 +91,16 @@ async function scrapeVersions() {
     console.error(`Strategy 1 error: ${e.message}`);
   }
 
-  // Strategy 2: Fallback - extract from page content
-  if (versionList.length === 0) {
-    console.error('Strategy 2 (fallback): Extracting from page content...');
+  // Strategy 2: Always scan page content for full 4-part versions.
+  // This augments Strategy 1 when v20+ filter-list items only expose a 3-part path
+  // (e.g. "CCSTUDIO/20.5.0") and the real build number lives in download URLs.
+  try {
+    console.error('Strategy 2: Scanning page content for 4-part version numbers...');
     const pageContent = await page.content();
     const versionMatches = pageContent.matchAll(/(\d+)\.(\d+)\.(\d+)\.(\d+)/g);
 
     for (const match of versionMatches) {
       const major = parseInt(match[1]);
-      // Filter out non-version numbers (e.g., dates, random numbers)
       if (major >= 7 && major <= 30) {
         versionList.push({
           version: `${match[1]}.${match[2]}.${match[3]}.${match[4]}`,
@@ -110,14 +111,23 @@ async function scrapeVersions() {
         });
       }
     }
+  } catch (e) {
+    console.error(`Strategy 2 error: ${e.message}`);
   }
 
   await browser.close();
 
-  // Deduplicate versions
-  const uniqueVersions = Array.from(
-    new Map(versionList.map(v => [v.version, v])).values()
-  );
+  // Deduplicate by major.minor.patch, preferring entries with a real build number
+  // over placeholder '0' added when the filter list only exposed a 3-part path.
+  const versionMap = new Map();
+  for (const v of versionList) {
+    const key = `${v.major}.${v.minor}.${v.patch}`;
+    const existing = versionMap.get(key);
+    if (!existing || (existing.build === '0' && v.build !== '0')) {
+      versionMap.set(key, v);
+    }
+  }
+  const uniqueVersions = Array.from(versionMap.values());
 
   // Sort by version (newest first)
   uniqueVersions.sort((a, b) => {

--- a/.github/workflows/build-all-versions.yml
+++ b/.github/workflows/build-all-versions.yml
@@ -37,7 +37,8 @@ jobs:
             VERSIONS=$(bash .github/scripts/parse-versions.sh)
           fi
 
-          echo "versions=${VERSIONS}" >> $GITHUB_OUTPUT
+          DELIMITER=$(openssl rand -hex 8)
+          { echo "versions<<${DELIMITER}"; echo "${VERSIONS}"; echo "${DELIMITER}"; } >> $GITHUB_OUTPUT
 
           # Extract latest version
           LATEST=$(echo "$VERSIONS" | jq -r '.[0].version')

--- a/.github/workflows/build-all-versions.yml
+++ b/.github/workflows/build-all-versions.yml
@@ -10,6 +10,9 @@ on:
         required: false
         default: ''
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   detect-versions:
     runs-on: ubuntu-latest
@@ -24,7 +27,7 @@ jobs:
         if: github.event.inputs.versions == ''
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
 
       - name: Parse CCS versions
         id: parse
@@ -120,6 +123,8 @@ jobs:
     needs: [detect-versions, build-and-push]
     runs-on: ubuntu-latest
     if: failure()
+    permissions:
+      issues: write
     steps:
       - name: Mark building issue as failed
         uses: actions/github-script@v7

--- a/.github/workflows/check-new-version.yml
+++ b/.github/workflows/check-new-version.yml
@@ -6,9 +6,15 @@ on:
     - cron: '0 0 * * 0'
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   check-new-version:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      actions: write
     steps:
       - name: Ensure required labels exist
         uses: actions/github-script@v7
@@ -45,12 +51,10 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '22'
 
       - name: Get all versions from TI
         id: ti-versions
-        env:
-          USE_SCRAPER: 'true'
         run: |
           echo "Fetching all versions from TI website..."
           ALL_VERSIONS=$(bash .github/scripts/parse-versions.sh)
@@ -92,7 +96,8 @@ jobs:
           ')
 
           MISSING_COUNT=$(echo "$MISSING" | jq '. | length')
-          echo "missing=${MISSING}" >> $GITHUB_OUTPUT
+          DELIMITER=$(openssl rand -hex 8)
+          { echo "missing<<${DELIMITER}"; echo "${MISSING}"; echo "${DELIMITER}"; } >> $GITHUB_OUTPUT
           echo "count=${MISSING_COUNT}" >> $GITHUB_OUTPUT
 
           echo "Missing versions: ${MISSING_COUNT}"

--- a/.github/workflows/check-new-version.yml
+++ b/.github/workflows/check-new-version.yml
@@ -56,7 +56,8 @@ jobs:
           ALL_VERSIONS=$(bash .github/scripts/parse-versions.sh)
           LATEST_VERSION=$(echo "$ALL_VERSIONS" | jq -r '.[0].version')
 
-          echo "versions=${ALL_VERSIONS}" >> $GITHUB_OUTPUT
+          DELIMITER=$(openssl rand -hex 8)
+          { echo "versions<<${DELIMITER}"; echo "${ALL_VERSIONS}"; echo "${DELIMITER}"; } >> $GITHUB_OUTPUT
           echo "latest=${LATEST_VERSION}" >> $GITHUB_OUTPUT
           echo "TI latest version: ${LATEST_VERSION}"
           echo "Total TI versions: $(echo "$ALL_VERSIONS" | jq '. | length')"

--- a/.github/workflows/update-versions-doc.yml
+++ b/.github/workflows/update-versions-doc.yml
@@ -6,9 +6,13 @@ on:
     types: [completed]
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   update-versions:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     permissions:
       contents: write
       issues: write

--- a/.github/workflows/update-versions-doc.yml
+++ b/.github/workflows/update-versions-doc.yml
@@ -9,9 +9,14 @@ on:
 jobs:
   update-versions:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Fetch Docker Hub versions
         id: fetch-versions


### PR DESCRIPTION
## Summary

This PR resolves all runner failures observed after the previous merge and addresses additional issues found during CI/CD review.

### Root Causes Fixed

**Runner failures (April 30)**
- `Build All CCS Versions` - `detect-versions` job wrote multi-line JSON to `\` via `echo "key=\"`, causing `Invalid format` errors
- `Update Versions Documentation` - `github-actions[bot]` lacked write permission to push commits

**Critical scraper bug**
- CCS v20+ versions are listed on the TI filter page as 3-part paths (`CCSTUDIO/20.5.0`), so the scraper produced `20.5.0.0` instead of `20.5.0.00028`
- This would cause `check-new-version.yml` to always detect v20 as "missing" from Docker Hub ? infinite rebuild loops with wrong download URLs

**Missing GitHub API permissions**
- `check-new-version.yml` had no `permissions` block - label creation, issue creation, and `workflow_dispatch` calls would silently fail
- `build-all-versions.yml` `handle-failure` job had no `issues: write` permission

**Logic error**
- `update-versions-doc.yml` triggered on ALL `Build All CCS Versions` completions including failures - could push stale docs

### Changes

| File | Change |
| --- | --- |
| `scrape-versions.js` | Strategy 2 (page content scan) always runs to recover build numbers; dedup prefers non-zero build over placeholder `0` |
| `merge-versions.js` | Compact JSON output to avoid `\` format errors |
| `build-all-versions.yml` | Heredoc delimiter for versions output; `issues: write` on handle-failure; Node 18?22; `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` |
| `check-new-version.yml` | `issues/actions: write` permissions; heredoc delimiter for missing output; remove dead `USE_SCRAPER` env var; Node 18?22 |
| `update-versions-doc.yml` | Only run on successful upstream build; `contents/issues: write` + explicit token; `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` |

## Test plan

- [ ] Push to main triggers `Build All CCS Versions` ? `detect-versions` completes without `Invalid format` errors
- [ ] Version output contains `20.5.0.00028` (not `20.5.0.0`)
- [ ] `Update Versions Documentation` runs only after successful build and can push to main
- [ ] `handle-failure` job successfully labels/comments on issues when builds fail
- [ ] Sunday `Check for New CCS Version` can create labels, issues, and trigger builds

?? Generated with [Claude Code](https://claude.com/claude-code)