### PR TITLE
🐛 Improve CI/CD stability and build reliability

### DIFF
--- a/.github/workflows/build-all-versions.yml
+++ b/.github/workflows/build-all-versions.yml
@@ -98,6 +98,7 @@ jobs:
   tag-latest:
     needs: [detect-versions, build-and-push]
     runs-on: ubuntu-latest
+    if: '!cancelled()'
     steps:
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -130,7 +131,7 @@ jobs:
   handle-failure:
     needs: [detect-versions, build-and-push]
     runs-on: ubuntu-latest
-    if: failure()
+    if: failure() && !cancelled()
     permissions:
       issues: write
     steps:

--- a/.github/workflows/build-all-versions.yml
+++ b/.github/workflows/build-all-versions.yml
@@ -61,6 +61,7 @@ jobs:
     needs: detect-versions
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 1
       matrix:
         version_info: ${{ fromJson(needs.detect-versions.outputs.build_versions) }}
       fail-fast: false

--- a/.github/workflows/check-new-version.yml
+++ b/.github/workflows/check-new-version.yml
@@ -71,17 +71,26 @@ jobs:
         run: |
           echo "Fetching existing tags from Docker Hub..."
 
-          # Get all tags from Docker Hub
-          TAGS=$(curl -s "https://hub.docker.com/v2/repositories/uoohyo/ccstudio-ide/tags?page_size=100" | jq -r '.results[].name' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' || echo "")
+          # Get all tags from Docker Hub (handle API errors gracefully)
+          RESPONSE=$(curl -s "https://hub.docker.com/v2/repositories/uoohyo/ccstudio-ide/tags?page_size=100")
 
-          if [ -z "$TAGS" ]; then
-            echo "No existing tags found on Docker Hub"
+          # Check if repository exists (API returns error object if not found)
+          if echo "$RESPONSE" | jq -e '.message' > /dev/null 2>&1; then
+            echo "Repository not found or API error: $(echo "$RESPONSE" | jq -r '.message')"
             echo "tags=[]" >> $GITHUB_OUTPUT
           else
-            # Convert to JSON array
-            TAGS_JSON=$(echo "$TAGS" | jq -R . | jq -s .)
-            echo "tags=${TAGS_JSON}" >> $GITHUB_OUTPUT
-            echo "Existing Docker Hub versions: $(echo "$TAGS_JSON" | jq '. | length')"
+            # Extract version tags
+            TAGS=$(echo "$RESPONSE" | jq -r '.results[].name' 2>/dev/null | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' || echo "")
+
+            if [ -z "$TAGS" ]; then
+              echo "No existing version tags found on Docker Hub"
+              echo "tags=[]" >> $GITHUB_OUTPUT
+            else
+              # Convert to JSON array
+              TAGS_JSON=$(echo "$TAGS" | jq -R . | jq -s .)
+              echo "tags=${TAGS_JSON}" >> $GITHUB_OUTPUT
+              echo "Existing Docker Hub versions: $(echo "$TAGS_JSON" | jq '. | length')"
+            fi
           fi
 
       - name: Find missing versions

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,10 +28,11 @@ RUN echo ">>> Downloading CCS ${CCS_VERSION}..." && \
     if [ "${MAJOR_VER}" -ge 20 ]; then \
         aria2c -x 16 -s 16 \
             --file-allocation=none \
-            --timeout=300 \
-            --max-tries=3 \
-            --console-log-level=error \
-            --summary-interval=0 \
+            --timeout=600 \
+            --max-tries=5 \
+            --retry-wait=3 \
+            --console-log-level=notice \
+            --summary-interval=10 \
             -o "CCS_${CCS_VERSION}_linux.zip" \
             "${CCS_URL}${MAJOR_VER}.${MINOR_VER}.${PATCH_VER}/CCS_${CCS_VERSION}_linux.zip" && \
         echo ">>> Download complete: $(du -h CCS_${CCS_VERSION}_linux.zip | cut -f1)" && \
@@ -46,14 +47,17 @@ RUN echo ">>> Downloading CCS ${CCS_VERSION}..." && \
         else \
             CCS_DL_PATH="${CCS_VERSION}"; \
         fi && \
+        DOWNLOAD_URL="${CCS_URL}${CCS_DL_PATH}/CCS${CCS_VERSION}_linux-x64.tar.gz" && \
+        echo ">>> Download URL: ${DOWNLOAD_URL}" && \
         aria2c -x 16 -s 16 \
             --file-allocation=none \
-            --timeout=300 \
-            --max-tries=3 \
-            --console-log-level=error \
-            --summary-interval=0 \
+            --timeout=600 \
+            --max-tries=5 \
+            --retry-wait=3 \
+            --console-log-level=notice \
+            --summary-interval=10 \
             -o "CCS${CCS_VERSION}_linux-x64.tar.gz" \
-            "${CCS_URL}${CCS_DL_PATH}/CCS${CCS_VERSION}_linux-x64.tar.gz" && \
+            "${DOWNLOAD_URL}" && \
         echo ">>> Download complete: $(du -h CCS${CCS_VERSION}_linux-x64.tar.gz | cut -f1)" && \
         echo ">>> Extracting installer..." && \
         tar -zxf "CCS${CCS_VERSION}_linux-x64.tar.gz" -C /ccs_installer && \


### PR DESCRIPTION
## Summary
- ✅ Enable sequential builds (oldest to newest) to prevent version mixing
- ✅ Fix download timeout issues for large installers (v7.1.0.00016)
- ✅ Improve Docker Hub API error handling in version check workflow
- ✅ Ensure workflow jobs run even with partial build failures

## Key Changes

### 🔧 Sequential Build Execution
**File:** `.github/workflows/build-all-versions.yml`
- Added `max-parallel: 1` to build strategy
- Ensures versions are built **one at a time in ascending order** (v7 → v8 → ... → v20)
- Prevents version mixing when running parallel builds

### 🐛 Download Reliability Improvements
**File:** `Dockerfile`
- Increased timeout: **300s → 600s** (10 minutes)
- Increased retry attempts: **3 → 5**
- Added `--retry-wait=3` for better retry handling
- Enhanced logging: `--console-log-level=notice`, `--summary-interval=10`
- Added download URL logging for debugging
- **Fixes:** Build failures for large installers like v7.1.0.00016 (721MB)

### 🔧 Workflow Robustness
**File:** `.github/workflows/build-all-versions.yml`
- `tag-latest` job: Added `if: '!cancelled()'`
  - Now runs even if some builds fail
  - Updates `latest` tag with the newest successfully built version
- `handle-failure` job: Updated to `if: failure() && !cancelled()`
  - Properly creates issues for failed builds
  - Only skipped if workflow is manually cancelled

### 🐛 Docker Hub API Error Handling
**File:** `.github/workflows/check-new-version.yml`
- Added proper error checking for Docker Hub API responses
- Handles repository not found errors gracefully
- **Fixes:** May 3, 2026 workflow failure when repository didn't exist

## Test Plan
- [x] Verified download URL for v7.1.0.00016 (721MB) - returns HTTP 200
- [x] Tested Docker Hub API error handling with non-existent repository
- [x] Confirmed sequential build configuration (`max-parallel: 1`)
- [x] Validated workflow job conditions (`!cancelled()`)

## Commits
```
856ef39 🔧 ensure tag-latest and handle-failure jobs run even with partial build failures
e08a836 🐛 fix Docker Hub API error handling in version check workflow
775ce54 🔧 enable sequential builds and fix download timeout for large installers
```

## Related Issues
- Fixes the May 3, 2026 "Check for New CCS Version" workflow failure
- Addresses 7.1.0.00016 build timeout issues

## Breaking Changes
None. All changes are backward compatible.
