### PR TITLE
🐛 fix: v20+ ccs-server-cli verification (wait condition + correct command)

### DIFF
--- a/.github/workflows/build-all-versions.yml
+++ b/.github/workflows/build-all-versions.yml
@@ -154,14 +154,15 @@ jobs:
           # Test CCS executable
           echo "→ Testing CCS executable..."
           if [ "$MAJOR" -ge 20 ]; then
-            # v20+: Theia-based server, no traditional -help flag.
-            # Entrypoint already verified the file; just confirm it's executable.
-            if ! docker exec "$CONTAINER_ID" test -x /opt/ti/ccs/eclipse/ccs-server-cli.sh 2>/dev/null; then
-              echo "❌ FAILED: ccs-server-cli.sh not executable"
+            # v20+: ccs-server-cli requires -noSplash -workspace <dir> -application <app> -ccs.help
+            # (bare -help is not a valid flag and produces no output)
+            if ! docker exec "$CONTAINER_ID" bash -c \
+              'mkdir -p /tmp/ccs_verify && /opt/ti/ccs/eclipse/ccs-server-cli.sh -noSplash -workspace /tmp/ccs_verify -application com.ti.ccs.apps.inspect -ccs.help 2>&1 | grep -q "Usage:"'; then
+              echo "❌ FAILED: ccs-server-cli not working properly"
               docker rm -f "$CONTAINER_ID"
               exit 1
             fi
-            echo "✓ ccs-server-cli.sh is executable"
+            echo "✓ ccs-server-cli is working"
           elif [ "$MAJOR" -ge 9 ]; then
             # v9-v12: Test eclipse at /opt/ti/ccs
             if ! docker exec "$CONTAINER_ID" /opt/ti/ccs/eclipse/eclipse -help 2>&1 | head -20 | grep -q "Eclipse"; then

--- a/.github/workflows/build-all-versions.yml
+++ b/.github/workflows/build-all-versions.yml
@@ -154,10 +154,11 @@ jobs:
           # Test CCS executable
           echo "→ Testing CCS executable..."
           if [ "$MAJOR" -ge 20 ]; then
-            # v20+: ccs-server-cli requires -noSplash -workspace <dir> -application <app> -ccs.help
-            # (bare -help is not a valid flag and produces no output)
+            # v20+: ccs-server-cli.sh uses $PWD to locate its bundled node and plugins,
+            # so it must be run from the eclipse directory.
+            # Bare -help is not a valid flag; use -ccs.help with a required application.
             if ! docker exec "$CONTAINER_ID" bash -c \
-              'mkdir -p /tmp/ccs_verify && /opt/ti/ccs/eclipse/ccs-server-cli.sh -noSplash -workspace /tmp/ccs_verify -application com.ti.ccs.apps.inspect -ccs.help 2>&1 | grep -q "Usage:"'; then
+              'mkdir -p /tmp/ccs_verify && cd /opt/ti/ccs/eclipse && ./ccs-server-cli.sh -noSplash -workspace /tmp/ccs_verify -application com.ti.ccs.apps.inspect -ccs.help 2>&1 | grep -q "Usage:"'; then
               echo "❌ FAILED: ccs-server-cli not working properly"
               docker rm -f "$CONTAINER_ID"
               exit 1

--- a/.github/workflows/build-all-versions.yml
+++ b/.github/workflows/build-all-versions.yml
@@ -117,8 +117,10 @@ jobs:
 
           while [ $ELAPSED -lt $MAX_WAIT ]; do
             if [ "$MAJOR" -ge 20 ]; then
-              # v20+: Check for ccs-server-cli
-              if docker exec "$CONTAINER_ID" test -f /opt/ti/ccs/eclipse/ccs-server-cli.sh 2>/dev/null; then
+              # v20+: ccs-server-cli.sh is extracted within seconds but full install takes minutes.
+              # Wait until it's executable AND /opt/ccs-installer is gone (entrypoint completed).
+              if docker exec "$CONTAINER_ID" test -x /opt/ti/ccs/eclipse/ccs-server-cli.sh 2>/dev/null && \
+                 ! docker exec "$CONTAINER_ID" test -d /opt/ccs-installer 2>/dev/null; then
                 INSTALLED=true
                 break
               fi
@@ -152,13 +154,14 @@ jobs:
           # Test CCS executable
           echo "→ Testing CCS executable..."
           if [ "$MAJOR" -ge 20 ]; then
-            # v20+: Test ccs-server-cli
-            if ! docker exec "$CONTAINER_ID" /opt/ti/ccs/eclipse/ccs-server-cli.sh -help 2>&1 | grep -q "Usage:"; then
-              echo "❌ FAILED: ccs-server-cli not working properly"
+            # v20+: Theia-based server, no traditional -help flag.
+            # Entrypoint already verified the file; just confirm it's executable.
+            if ! docker exec "$CONTAINER_ID" test -x /opt/ti/ccs/eclipse/ccs-server-cli.sh 2>/dev/null; then
+              echo "❌ FAILED: ccs-server-cli.sh not executable"
               docker rm -f "$CONTAINER_ID"
               exit 1
             fi
-            echo "✓ ccs-server-cli is working"
+            echo "✓ ccs-server-cli.sh is executable"
           elif [ "$MAJOR" -ge 9 ]; then
             # v9-v12: Test eclipse at /opt/ti/ccs
             if ! docker exec "$CONTAINER_ID" /opt/ti/ccs/eclipse/eclipse -help 2>&1 | head -20 | grep -q "Eclipse"; then


### PR DESCRIPTION
## Summary

Fixes v20+ CCS image verification logic. All three issues were reproduced and verified via local container test.

### Root Causes

- **Wait condition fires too early**: `ccs-server-cli.sh` is extracted to the install path within ~20 seconds of the installer starting, long before the full installation completes
- **Wrong flag**: Bare `-help` is not a valid flag for `ccs-server-cli.sh` — it produces no output
- **Wrong working directory**: `ccs-server-cli.sh` uses `$PWD` to locate its bundled Node.js binary and plugins; running it from any directory other than `/opt/ti/ccs/eclipse/` results in `node: not found`

### Changes

- **Wait condition**: Now checks both `ccs-server-cli.sh` is executable AND `/opt/ccs-installer` directory is gone — the entrypoint only removes that directory after a successful install and verification
- **Verification command**: Changed to `-noSplash -workspace /tmp/ccs_verify -application com.ti.ccs.apps.inspect -ccs.help`, which outputs `Usage:` on success
- **Working directory**: Added `cd /opt/ti/ccs/eclipse` before executing the script
- v7–v12 (`eclipse`-based) wait condition is unchanged — the `eclipse` binary only appears after full installation, so the original single-condition check was already correct

## Test plan

- [ ] Confirm v20+ build passes the test step end-to-end on GitHub Actions
- [ ] Confirm v7–v12 builds continue to pass without regression