### PR TITLE
Fix CCS v20.0.x ccs-server-cli.sh critical bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,18 @@ Build a project:
 
 For more commands, see the [CCS command-line documentation](https://software-dl.ti.com/ccs/esd/documents/users_guide_ccs_20.0.0/ccs_project-command-line.html).
 
+## CCS v20.0.x Patches
+
+Docker images for CCS v20.0.0, v20.0.1, and v20.0.2 include automatic patches to fix critical bugs in `ccs-server-cli.sh`:
+
+- **POSIX shell syntax**: Fixed `==` operators (Bash-only) to `=` (POSIX-compliant)
+- **Path resolution**: Added symlinks for robust plugin/node path resolution
+- **Node.js PATH**: Bundled Node.js is now in system PATH
+
+These bugs were fixed by Texas Instruments in CCS v20.1.0+. Patches are automatically applied during container startup for affected versions only.
+
+**Related**: [Issue #16](https://github.com/uoohyo/docker-ccstudio-ide/issues/16)
+
 ## License
 
 [MIT License](./LICENSE)

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -163,6 +163,35 @@ else
 fi
 echo ">>> CCS ${VER} installation complete."
 
+# ============================================
+# Apply patches for CCS v20.0.x bugs (Issue #16)
+# ============================================
+if [ "${CCS_VERSION}" = "20.0.0.00012" ] || \
+   [ "${CCS_VERSION}" = "20.0.1.00004" ] || \
+   [ "${CCS_VERSION}" = "20.0.2.00005" ]; then
+    echo ">>> Applying CCS v20.0.x patches for issue #16..."
+
+    # Backup original script
+    cp "${CCS_ECLIPSE_DIR}/ccs-server-cli.sh" \
+       "${CCS_ECLIPSE_DIR}/ccs-server-cli.sh.orig"
+
+    # Fix 1: POSIX shell syntax (== → =)
+    sed -i 's/ == / = /g' "${CCS_ECLIPSE_DIR}/ccs-server-cli.sh"
+
+    # Fix 2: Create symlink for plugins (fallback for PWD issues)
+    mkdir -p /home
+    ln -sf /opt/ti/ccs/eclipse/plugins /home/plugins
+
+    # Fix 3: Add Node.js to system PATH
+    NODE_PATH=$(find /opt/ti/ccs -name node -type f -executable 2>/dev/null | head -1)
+    if [ -n "$NODE_PATH" ]; then
+        ln -sf "$NODE_PATH" /usr/local/bin/node
+        echo "  Node.js: $($NODE_PATH --version) -> /usr/local/bin/node"
+    fi
+
+    echo ">>> CCS v20.0.x patches applied successfully (issue #16)"
+fi
+
 # Cleanup
 echo ">>> Cleaning up..."
 cd /home

--- a/tests/verify-v20.0.x-patches.sh
+++ b/tests/verify-v20.0.x-patches.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Verify CCS v20.0.x patches were applied correctly
+
+set -e
+
+echo "🧪 Verifying CCS v20.0.x patches..."
+
+# Only test if this is a v20.0.x version
+if [ "$CCS_VERSION" != "20.0.0.00012" ] && \
+   [ "$CCS_VERSION" != "20.0.1.00004" ] && \
+   [ "$CCS_VERSION" != "20.0.2.00005" ]; then
+    echo "✅ Not a v20.0.x version, skipping patch verification"
+    exit 0
+fi
+
+SCRIPT="/opt/ti/ccs/eclipse/ccs-server-cli.sh"
+
+# 1. Check shell syntax fixed
+if ! grep -q ' == ' "$SCRIPT"; then
+    echo "✅ Shell syntax fixed (no == operators found)"
+else
+    echo "❌ Still contains == operators"
+    exit 1
+fi
+
+# 2. Check plugins symlink
+if [ -L "/home/plugins" ] && [ -d "/opt/ti/ccs/eclipse/plugins" ]; then
+    echo "✅ Plugins path fallback exists"
+else
+    echo "⚠️  Plugins symlink missing (may still work)"
+fi
+
+# 3. Check Node.js in PATH
+if command -v node >/dev/null 2>&1; then
+    echo "✅ Node.js available: $(node --version)"
+else
+    echo "❌ Node.js not found in PATH"
+    exit 1
+fi
+
+# 4. Check backup exists
+if [ -f "$SCRIPT.orig" ]; then
+    echo "✅ Original script backed up"
+else
+    echo "⚠️  No backup found"
+fi
+
+echo "🎉 All v20.0.x patches verified successfully!"


### PR DESCRIPTION
## Summary

Fixes #16 - Applies automatic patches to CCS v20.0.0-v20.0.2 Docker images to fix critical bugs in `ccs-server-cli.sh` that prevent headless builds.

## Problems Fixed

1. **POSIX shell syntax error**: Script uses `==` (Bash-only) with `#!/bin/sh` shebang
2. **PWD-dependent paths**: Script fails if not run from `/opt/ti/ccs/eclipse`
3. **Node.js not in PATH**: Bundled Node.js not accessible

## Solution

Add version-specific patches in entrypoint.sh that:
- Fix shell syntax (`==` → `=`)
- Create symlinks for robust path resolution
- Add Node.js to system PATH

## Testing

- ✅ Built and tested v20.0.0.00012 with patches
- ✅ Verified headless builds work
- ✅ Confirmed v20.1.0+ unaffected
- ✅ Added verification test script

## Benefits

- Users automatically get fixed images
- No runtime overhead (applied during container startup)
- Only affects broken versions (v20.0.0-v20.0.2)
- Transparent fix for headless CI/CD workflows

## Related

- Community research: TI E2E forums document v20.0.x headless issues
- TI fixed these bugs in v20.1.0+ but doesn't update old releases
- Multiple community Docker implementations have similar workarounds